### PR TITLE
Fixed typo in interface

### DIFF
--- a/src/client/interfaces/ServerFile.ts
+++ b/src/client/interfaces/ServerFile.ts
@@ -40,5 +40,5 @@ export interface ServerFileAttributes {
 
 export interface ServerFile {
   object: string;
-  atributes: ServerFileAttributes;
+  attributes: ServerFileAttributes;
 }


### PR DESCRIPTION
There was a typo in `attributes` as it was missing one `t`